### PR TITLE
Renamed aws env vars

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,8 +3,8 @@ const AWS = require('aws-sdk');
 const siteConfig = require('./site-config');
 
 AWS.config.update({
-  accessKeyId: process.env.ACCESS_KEY_ID,
-  secretAccessKey: process.env.SECRET_ACCESS_KEY,
+  accessKeyId: process.env.S3_ACCESS_KEY_ID,
+  secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
 });
 
 module.exports = {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,8 +3,8 @@ const AWS = require('aws-sdk');
 const siteConfig = require('./site-config');
 
 AWS.config.update({
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  accessKeyId: process.env.ACCESS_KEY_ID,
+  secretAccessKey: process.env.SECRET_ACCESS_KEY,
 });
 
 module.exports = {


### PR DESCRIPTION
Removed `AWS_` prefix from environment variables to support amplify