### PR TITLE
chore: update v2.5.0b to point to v2.5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Run linting
         run: yarn lint

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ public/sitemap*.xml
 public/robots.txt
 .yarn/cache
 .yarn/install-state.gz
+
+# Claude settings (user-local)
+.claude/settings.local.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:25-bookworm
+FROM node:26-bookworm
 
 WORKDIR /opt
 

--- a/next.config.js
+++ b/next.config.js
@@ -25,6 +25,15 @@ const next_config = {
     nextImageExportOptimizer_generateAndUseBlurImages: true,
   },
   productionBrowserSourceMaps: true,
+  webpack: (config, { isServer }) => {
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      'styled-components': isServer
+        ? 'styled-components/esm'
+        : 'styled-components',
+    };
+    return config;
+  },
 };
 
 export default withBundleAnalyzer(next_config);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-plugin-styled-components": "^2.0.7",
     "contentful": "^9.2.14",
     "dotenv": "^10.0.0",
-    "framer-motion": "10",
+    "framer-motion": "10.18.0",
     "next": "^13.1.1",
     "next-image-export-optimizer": "^1.1.2",
     "prop-types": "^15.6.2",
@@ -46,7 +46,7 @@
     "react-images": "^1.2.0-beta.7",
     "react-photo-gallery": "^8.0.0",
     "react-syntax-highlighter": "^15.5.0",
-    "styled-components": "6",
+    "styled-components": "6.4.2",
     "xml2js": "^0.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "babel-plugin-styled-components": "^2.0.7",
     "contentful": "^9.2.14",
     "dotenv": "^10.0.0",
-    "framer-motion": "^5.2.1",
+    "framer-motion": "10",
     "next": "^13.1.1",
     "next-image-export-optimizer": "^1.1.2",
     "prop-types": "^15.6.2",
@@ -46,7 +46,7 @@
     "react-images": "^1.2.0-beta.7",
     "react-photo-gallery": "^8.0.0",
     "react-syntax-highlighter": "^15.5.0",
-    "styled-components": "^5.3.6",
+    "styled-components": "6",
     "xml2js": "^0.5.0"
   },
   "devDependencies": {

--- a/src/components/carousel/carousel.test.jsx
+++ b/src/components/carousel/carousel.test.jsx
@@ -5,7 +5,6 @@ vi.mock('react-images', () => {
   const mockCarousel = vi.fn(({ views, currentIndex }) => (
     <div data-testid="mock-carousel">
       {views.map((v, i) => {
-        const isActive = v.id === String(currentIndex);
         return (
           <div key={i} data-testid="carousel-view" data-index={i}>
             <img src={v.src} alt={v.alt} width={v.width} height={v.height} />
@@ -39,7 +38,7 @@ const mockViews = [
 test('renders modal and carousel with provided props', () => {
   const onClose = vi.fn();
   render(
-    <CarouselModal onClose={onClose} currentIndex="1" views={mockViews} />
+    <CarouselModal onClose={onClose} currentIndex={1} views={mockViews} />
   );
 
   expect(screen.getByTestId('mock-modal')).toBeInTheDocument();
@@ -50,7 +49,7 @@ test('renders modal and carousel with provided props', () => {
 test('calls onClose when modal is clicked', () => {
   const onClose = vi.fn();
   render(
-    <CarouselModal onClose={onClose} currentIndex="0" views={mockViews} />
+    <CarouselModal onClose={onClose} currentIndex={0} views={mockViews} />
   );
   fireEvent.click(screen.getByTestId('mock-modal'));
   expect(onClose).toHaveBeenCalled();
@@ -60,7 +59,7 @@ test('currentIndex prop controls view rendering', () => {
   const onClose = vi.fn();
 
   render(
-    <CarouselModal onClose={onClose} currentIndex="1" views={mockViews} />
+    <CarouselModal onClose={onClose} currentIndex={1} views={mockViews} />
   );
 
   const viewElements = screen.getAllByTestId('carousel-view');
@@ -76,7 +75,6 @@ test('currentIndex prop controls view rendering', () => {
   
   // Verify carousel mock was called with correct currentIndex
   expect(mockCarousel).toHaveBeenCalledWith(
-    { views: mockViews, currentIndex: '1' },
-    expect.anything()
+    { views: mockViews, currentIndex: '1' }
   );
 });

--- a/src/components/carousel/carousel.test.jsx
+++ b/src/components/carousel/carousel.test.jsx
@@ -73,7 +73,7 @@ test('currentIndex prop controls view rendering', () => {
   // Verify second element has correct index
   expect(viewElements[1]).toHaveAttribute('data-index', '1');
 
-  // Verify carousel mock was called with correct props (partial match to avoid issues with extra React args)
-  const lastCall = mockCarousel.mock.calls[2][0];
+  // Verify carousel mock was called with correct props
+  const lastCall = mockCarousel.mock.calls[mockCarousel.mock.calls.length - 1][0];
   expect(lastCall).toMatchObject({ views: mockViews, currentIndex: 1 });
 });

--- a/src/components/carousel/carousel.test.jsx
+++ b/src/components/carousel/carousel.test.jsx
@@ -73,6 +73,7 @@ test('currentIndex prop controls view rendering', () => {
   // Verify second element has correct index
   expect(viewElements[1]).toHaveAttribute('data-index', '1');
 
-  // Verify carousel mock was called with correct currentIndex
-  expect(mockCarousel.mock.calls[2][0]).toEqual({ views: mockViews, currentIndex: 1 });
+  // Verify carousel mock was called with correct props (partial match to avoid issues with extra React args)
+  const lastCall = mockCarousel.mock.calls[2][0];
+  expect(lastCall).toMatchObject({ views: mockViews, currentIndex: 1 });
 });

--- a/src/components/carousel/carousel.test.jsx
+++ b/src/components/carousel/carousel.test.jsx
@@ -2,16 +2,9 @@ import { test, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 vi.mock('react-images', () => {
-  const MockModal = ({ onClose, children }) => (
-    <div data-testid="mock-modal" onClick={onClose}>
-      {children}
-    </div>
-  );
-
-  const MockCarousel = ({ views, currentIndex }) => (
+  const mockCarousel = vi.fn(({ views, currentIndex }) => (
     <div data-testid="mock-carousel">
       {views.map((v, i) => {
-        // Only render the view that matches currentIndex
         const isActive = v.id === String(currentIndex);
         return (
           <div key={i} data-testid="carousel-view" data-index={i}>
@@ -20,12 +13,23 @@ vi.mock('react-images', () => {
         );
       })}
     </div>
+  ));
+
+  const mockModal = ({ onClose, children }) => (
+    <div data-testid="mock-modal" onClick={onClose}>
+      {children}
+    </div>
   );
 
-  return { __esModule: true, default: MockCarousel, Modal: MockModal, Carousel: MockCarousel };
+  return {
+    __esModule: true,
+    default: mockCarousel,
+    Modal: mockModal,
+  };
 });
 
 import CarouselModal from './carousel.jsx';
+const { default: mockCarousel } = await import('react-images');
 
 const mockViews = [
   { id: '0', src: 'a.jpg', alt: 'A', width: 100, height: 100 },
@@ -54,34 +58,6 @@ test('calls onClose when modal is clicked', () => {
 
 test('currentIndex prop controls view rendering', () => {
   const onClose = vi.fn();
-  
-  // Mock the Carousel component to verify currentIndex is passed correctly
-  vi.mock('react-images', () => {
-    const MockModal = ({ onClose, children }) => (
-      <div data-testid="mock-modal" onClick={onClose}>
-        {children}
-      </div>
-    );
-
-    const MockCarousel = ({ views, currentIndex }) => {
-      // Store currentIndex for assertion
-      MockCarousel.mockCurrentIndex = currentIndex;
-      return (
-        <div data-testid="mock-carousel">
-          {views.map((v, i) => {
-            const isActive = v.id === String(currentIndex);
-            return (
-              <div key={i} data-testid="carousel-view" data-index={i}>
-                <img src={v.src} alt={v.alt} width={v.width} height={v.height} />
-              </div>
-            );
-          })}
-        </div>
-      );
-    };
-
-    return { __esModule: true, default: MockCarousel, Modal: MockModal, Carousel: MockCarousel };
-  });
 
   render(
     <CarouselModal onClose={onClose} currentIndex="1" views={mockViews} />
@@ -98,6 +74,9 @@ test('currentIndex prop controls view rendering', () => {
   // Verify second element has correct index
   expect(viewElements[1]).toHaveAttribute('data-index', '1');
   
-  // Verify currentIndex was passed to the mock (indirectly verified by correct rendering)
-  expect(MockCarousel.mockCurrentIndex).toBe('1');
+  // Verify carousel mock was called with correct currentIndex
+  expect(mockCarousel).toHaveBeenCalledWith(
+    { views: mockViews, currentIndex: '1' },
+    expect.anything()
+  );
 });

--- a/src/components/carousel/carousel.test.jsx
+++ b/src/components/carousel/carousel.test.jsx
@@ -63,18 +63,16 @@ test('currentIndex prop controls view rendering', () => {
   );
 
   const viewElements = screen.getAllByTestId('carousel-view');
-  
+
   // Verify we have the expected number of elements
   expect(viewElements).toHaveLength(2);
-  
+
   // Verify first element has correct index
   expect(viewElements[0]).toHaveAttribute('data-index', '0');
-  
+
   // Verify second element has correct index
   expect(viewElements[1]).toHaveAttribute('data-index', '1');
-  
+
   // Verify carousel mock was called with correct currentIndex
-  expect(mockCarousel).toHaveBeenCalledWith(
-    { views: mockViews, currentIndex: '1' }
-  );
+  expect(mockCarousel.mock.calls[2][0]).toEqual({ views: mockViews, currentIndex: 1 });
 });

--- a/src/components/carousel/carousel.test.jsx
+++ b/src/components/carousel/carousel.test.jsx
@@ -54,6 +54,35 @@ test('calls onClose when modal is clicked', () => {
 
 test('currentIndex prop controls view rendering', () => {
   const onClose = vi.fn();
+  
+  // Mock the Carousel component to verify currentIndex is passed correctly
+  vi.mock('react-images', () => {
+    const MockModal = ({ onClose, children }) => (
+      <div data-testid="mock-modal" onClick={onClose}>
+        {children}
+      </div>
+    );
+
+    const MockCarousel = ({ views, currentIndex }) => {
+      // Store currentIndex for assertion
+      MockCarousel.mockCurrentIndex = currentIndex;
+      return (
+        <div data-testid="mock-carousel">
+          {views.map((v, i) => {
+            const isActive = v.id === String(currentIndex);
+            return (
+              <div key={i} data-testid="carousel-view" data-index={i}>
+                <img src={v.src} alt={v.alt} width={v.width} height={v.height} />
+              </div>
+            );
+          })}
+        </div>
+      );
+    };
+
+    return { __esModule: true, default: MockCarousel, Modal: MockModal, Carousel: MockCarousel };
+  });
+
   render(
     <CarouselModal onClose={onClose} currentIndex="1" views={mockViews} />
   );
@@ -68,4 +97,7 @@ test('currentIndex prop controls view rendering', () => {
   
   // Verify second element has correct index
   expect(viewElements[1]).toHaveAttribute('data-index', '1');
+  
+  // Verify currentIndex was passed to the mock (indirectly verified by correct rendering)
+  expect(MockCarousel.mockCurrentIndex).toBe('1');
 });

--- a/src/components/footer/footer.jsx
+++ b/src/components/footer/footer.jsx
@@ -64,13 +64,13 @@ const Footer = ({ author, social }) => (
 );
 
 Footer.propTypes = {
-  author: PropTypes.string,
+  author: PropTypes.string.isRequired,
   social: PropTypes.shape({
     github: PropTypes.string,
     linkedin: PropTypes.string,
     flickr: PropTypes.string,
     fivehundredpx: PropTypes.string,
-  }),
+  }).isRequired,
 };
 
 export default Footer;

--- a/src/components/image/baseImage.test.jsx
+++ b/src/components/image/baseImage.test.jsx
@@ -2,7 +2,15 @@ import { test, expect } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 vi.mock('./image.css.js', () => ({
-  SImage: ({ src, alt, ...rest }) => <img data-testid="mock-simage" src={src} alt={alt} {...rest} />,
+  SImage: ({ src, alt, onError, ...rest }) => (
+    <img 
+      data-testid="mock-simage" 
+      src={src} 
+      alt={alt} 
+      onError={onError}
+      {...rest} 
+    />
+  ),
 }));
 
 import BaseImage from './baseImage.jsx';
@@ -14,19 +22,6 @@ test('renders image with valid src', () => {
 });
 
 test('falls back to backupSrc on error', () => {
-  // Mock the SImage to support onerror and track src changes
-  vi.mock('./image.css.js', () => ({
-    SImage: ({ src, alt, onError, ...rest }) => (
-      <img 
-        data-testid="mock-simage" 
-        src={src} 
-        alt={alt} 
-        onError={onError}
-        {...rest} 
-      />
-    ),
-  }));
-
   const { container } = render(
     <BaseImage src="/nonexistent.jpg" alt="Test image" backupSrc="/fallback.jpg" />
   );
@@ -39,7 +34,7 @@ test('falls back to backupSrc on error', () => {
   fireEvent.error(imgElement);
 
   // Check that src changed to backupSrc after error
-  const updatedImg = screen.getByTestId('mock-simage');
+  const updatedImg = screen.getByAltText('Test image');
   expect(updatedImg).toHaveAttribute('src', '/fallback.jpg');
   
   // Verify the img element is still in the document
@@ -75,19 +70,6 @@ test('handles fill prop with sizes attribute', () => {
 });
 
 test('error handler sets isError state', () => {
-  // Re-mock with onError support
-  vi.mock('./image.css.js', () => ({
-    SImage: ({ src, alt, onError, ...rest }) => (
-      <img 
-        data-testid="mock-simage" 
-        src={src} 
-        alt={alt} 
-        onError={onError}
-        {...rest} 
-      />
-    ),
-  }));
-
   const { rerender } = render(<BaseImage src="/error.jpg" alt="Error test" backupSrc="/fallback.jpg" />);
 
   const imgElement = screen.getByAltText('Error test');
@@ -97,3 +79,4 @@ test('error handler sets isError state', () => {
 
   expect(screen.getByAltText('Error test')).toBeInTheDocument();
 });
+

--- a/src/components/image/baseImage.test.jsx
+++ b/src/components/image/baseImage.test.jsx
@@ -70,7 +70,7 @@ test('handles fill prop with sizes attribute', () => {
 });
 
 test('error handler sets isError state', () => {
-  const { rerender } = render(<BaseImage src="/error.jpg" alt="Error test" backupSrc="/fallback.jpg" />);
+  render(<BaseImage src="/error.jpg" alt="Error test" backupSrc="/fallback.jpg" />);
 
   const imgElement = screen.getByAltText('Error test');
   

--- a/src/components/image/baseImage.test.jsx
+++ b/src/components/image/baseImage.test.jsx
@@ -14,9 +14,7 @@ test('renders image with valid src', () => {
 });
 
 test('falls back to backupSrc on error', () => {
-  const mockOnError = vi.fn();
-  
-  // Mock the SImage to support onerror
+  // Mock the SImage to support onerror and track src changes
   vi.mock('./image.css.js', () => ({
     SImage: ({ src, alt, onError, ...rest }) => (
       <img 
@@ -29,16 +27,23 @@ test('falls back to backupSrc on error', () => {
     ),
   }));
 
-  const { rerender } = render(
+  const { container } = render(
     <BaseImage src="/nonexistent.jpg" alt="Test image" backupSrc="/fallback.jpg" />
   );
 
-  // Simulate image error
+  // Verify initial src is the primary one
   const imgElement = screen.getByTestId('mock-simage');
+  expect(imgElement).toHaveAttribute('src', '/nonexistent.jpg');
+
+  // Simulate image error
   fireEvent.error(imgElement);
 
-  // Check that backupSrc is rendered after error
-  expect(screen.getByAltText('Test image')).toBeInTheDocument();
+  // Check that src changed to backupSrc after error
+  const updatedImg = screen.getByTestId('mock-simage');
+  expect(updatedImg).toHaveAttribute('src', '/fallback.jpg');
+  
+  // Verify the img element is still in the document
+  expect(updatedImg).toBeInTheDocument();
 });
 
 test('accepts additional props', () => {

--- a/src/components/image/baseImage.test.jsx
+++ b/src/components/image/baseImage.test.jsx
@@ -22,7 +22,7 @@ test('renders image with valid src', () => {
 });
 
 test('falls back to backupSrc on error', () => {
-  const { container } = render(
+  render(
     <BaseImage src="/nonexistent.jpg" alt="Test image" backupSrc="/fallback.jpg" />
   );
 

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -6,7 +6,7 @@ import GlobalStyle from 'global.css.js';
 const MyApp = ({ Component, pageProps, router }) => (
   <>
     <GlobalStyle />
-    <AnimatePresence exitBeforeEnter>
+    <AnimatePresence mode="wait">
       <Component {...pageProps} key={router.route} />
     </AnimatePresence>
   </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5380,7 +5380,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:10":
+"framer-motion@npm:10.18.0":
   version: 10.18.0
   resolution: "framer-motion@npm:10.18.0"
   dependencies:
@@ -6078,7 +6078,7 @@ __metadata:
     eslint-config-prettier: "npm:^8.3.0"
     esm: "npm:^3.2.25"
     favicons: "npm:^7.0.2"
-    framer-motion: "npm:10"
+    framer-motion: "npm:10.18.0"
     jsdom: "npm:^29.1.1"
     lighthouse: "npm:^8.6.0"
     mkdirp: "npm:^1.0.4"
@@ -6095,7 +6095,7 @@ __metadata:
     react-photo-gallery: "npm:^8.0.0"
     react-syntax-highlighter: "npm:^15.5.0"
     source-map-explorer: "npm:^2.5.3"
-    styled-components: "npm:6"
+    styled-components: "npm:6.4.2"
     vitest: "npm:^4.1.5"
     webpack: "npm:^5.76.0"
     xml2js: "npm:^0.5.0"
@@ -10794,7 +10794,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"styled-components@npm:6":
+"styled-components@npm:6.4.2":
   version: 6.4.2
   resolution: "styled-components@npm:6.4.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -144,7 +144,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.0.0, @babel/helper-module-imports@npm:^7.25.9, @babel/helper-module-imports@npm:^7.28.6":
+"@babel/helper-module-imports@npm:^7.25.9, @babel/helper-module-imports@npm:^7.28.6":
   version: 7.28.6
   resolution: "@babel/helper-module-imports@npm:7.28.6"
   dependencies:
@@ -349,7 +349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0, @babel/traverse@npm:^7.4.5":
+"@babel/traverse@npm:^7.28.6, @babel/traverse@npm:^7.29.0":
   version: 7.29.0
   resolution: "@babel/traverse@npm:7.29.0"
   dependencies:
@@ -528,21 +528,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emotion/is-prop-valid@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@emotion/is-prop-valid@npm:1.4.0"
+  dependencies:
+    "@emotion/memoize": "npm:^0.9.0"
+  checksum: 10c0/5f857814ec7d8c7e727727346dfb001af6b1fb31d621a3ce9c3edf944a484d8b0d619546c30899ae3ade2f317c76390ba4394449728e9bf628312defc2c41ac3
+  languageName: node
+  linkType: hard
+
 "@emotion/is-prop-valid@npm:^0.8.2":
   version: 0.8.8
   resolution: "@emotion/is-prop-valid@npm:0.8.8"
   dependencies:
     "@emotion/memoize": "npm:0.7.4"
   checksum: 10c0/f6be625f067c7fa56a12a4edaf090715616dc4fc7803c87212831f38c969350107b9709b1be54100e53153b18d9fa068eb4bf4f9ac66a37a8edf1bac9b64e279
-  languageName: node
-  linkType: hard
-
-"@emotion/is-prop-valid@npm:^1.1.0":
-  version: 1.4.0
-  resolution: "@emotion/is-prop-valid@npm:1.4.0"
-  dependencies:
-    "@emotion/memoize": "npm:^0.9.0"
-  checksum: 10c0/5f857814ec7d8c7e727727346dfb001af6b1fb31d621a3ce9c3edf944a484d8b0d619546c30899ae3ade2f317c76390ba4394449728e9bf628312defc2c41ac3
   languageName: node
   linkType: hard
 
@@ -557,20 +557,6 @@ __metadata:
   version: 0.9.0
   resolution: "@emotion/memoize@npm:0.9.0"
   checksum: 10c0/13f474a9201c7f88b543e6ea42f55c04fb2fdc05e6c5a3108aced2f7e7aa7eda7794c56bba02985a46d8aaa914fcdde238727a98341a96e2aec750d372dadd15
-  languageName: node
-  linkType: hard
-
-"@emotion/stylis@npm:^0.8.4":
-  version: 0.8.5
-  resolution: "@emotion/stylis@npm:0.8.5"
-  checksum: 10c0/f109e3f11cb0d48e8658aaa23578c5bcfe35e297819cfb089a3de6ba8dc0f89b0960474922690c6028df5d2e1895b4967f2fb280642c030054c312f1e137ce26
-  languageName: node
-  linkType: hard
-
-"@emotion/unitless@npm:^0.7.4":
-  version: 0.7.5
-  resolution: "@emotion/unitless@npm:0.7.5"
-  checksum: 10c0/4d0d94f53cb97b4481bbfa394953e1899a0b877644642ba9dd7247c27eb8c48e14e22aeb11411d7d9874685ad85dd5fb5b50eb78c6d8840eb56a84b92dcef2f4
   languageName: node
   linkType: hard
 
@@ -2655,7 +2641,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-styled-components@npm:>= 1.12.0, babel-plugin-styled-components@npm:^2.0.7":
+"babel-plugin-styled-components@npm:^2.0.7":
   version: 2.3.0
   resolution: "babel-plugin-styled-components@npm:2.3.0"
   dependencies:
@@ -3869,7 +3855,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css-to-react-native@npm:^3.0.0":
+"css-to-react-native@npm:3.2.0":
   version: 3.2.0
   resolution: "css-to-react-native@npm:3.2.0"
   dependencies:
@@ -3913,7 +3899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2":
+"csstype@npm:3.2.3, csstype@npm:^3.0.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
@@ -5394,41 +5380,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^5.2.1":
-  version: 5.6.0
-  resolution: "framer-motion@npm:5.6.0"
+"framer-motion@npm:10":
+  version: 10.18.0
+  resolution: "framer-motion@npm:10.18.0"
   dependencies:
     "@emotion/is-prop-valid": "npm:^0.8.2"
-    framesync: "npm:6.0.1"
-    hey-listen: "npm:^1.0.8"
-    popmotion: "npm:11.0.3"
-    react-merge-refs: "npm:^1.1.0"
-    react-use-measure: "npm:^2.1.1"
-    style-value-types: "npm:5.0.0"
-    tslib: "npm:^2.1.0"
+    tslib: "npm:^2.4.0"
   peerDependencies:
-    "@react-three/fiber": "*"
-    react: ">=16.8 || ^17.0.0"
-    react-dom: ">=16.8 || ^17.0.0"
-    three: ^0.135.0
+    react: ^18.0.0
+    react-dom: ^18.0.0
   dependenciesMeta:
     "@emotion/is-prop-valid":
       optional: true
   peerDependenciesMeta:
-    "@react-three/fiber":
+    react:
       optional: true
-    three:
+    react-dom:
       optional: true
-  checksum: 10c0/48df78fd6f2e0b895881108510158f36b5ec1271df10746c37396a6f6f5ac1ddb5e0f6b5c1856e0f04da412a65e2e0116bde0a5e76b31d28badff33c840dc356
-  languageName: node
-  linkType: hard
-
-"framesync@npm:6.0.1":
-  version: 6.0.1
-  resolution: "framesync@npm:6.0.1"
-  dependencies:
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/ce84ce548a8612be070204b9cf3ce7258acead2d51df05586995340e501d1439dfc1f9402ede921a9c0dde854d80fd46e97c699a3657f8d7abd5bc705553bf2b
+  checksum: 10c0/0aea1b3dc5cf06687e31f3b6c0b6b1a2cd070afdd4a9d38ebf15715c662ca1d6d1c25e6778695e5ebff37a6ce92b031d036c02570370e6057e66aa9de9f9370f
   languageName: node
   linkType: hard
 
@@ -5899,13 +5868,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hey-listen@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "hey-listen@npm:1.0.8"
-  checksum: 10c0/38db3028b4756f3d536c0f6a92da53bad577ab649b06dddfd0a4d953f9a46bbc6a7f693c8c5b466a538d6d23dbc469260c848427f0de14198a2bbecbac37b39e
-  languageName: node
-  linkType: hard
-
 "highlight.js@npm:^10.4.1, highlight.js@npm:~10.7.0":
   version: 10.7.3
   resolution: "highlight.js@npm:10.7.3"
@@ -5917,15 +5879,6 @@ __metadata:
   version: 1.0.0
   resolution: "highlightjs-vue@npm:1.0.0"
   checksum: 10c0/9be378c70b864ca5eee87b07859222e31c946a8ad176227e54f7006a498223974ebe19fcce6e38ad5eb3c1ed0e16a580c4edefdf2cb882b6dfab1c3866cc047a
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.0.0":
-  version: 3.3.2
-  resolution: "hoist-non-react-statics@npm:3.3.2"
-  dependencies:
-    react-is: "npm:^16.7.0"
-  checksum: 10c0/fe0889169e845d738b59b64badf5e55fa3cf20454f9203d1eb088df322d49d4318df774828e789898dcb280e8a5521bb59b3203385662ca5e9218a6ca5820e74
   languageName: node
   linkType: hard
 
@@ -6125,7 +6078,7 @@ __metadata:
     eslint-config-prettier: "npm:^8.3.0"
     esm: "npm:^3.2.25"
     favicons: "npm:^7.0.2"
-    framer-motion: "npm:^5.2.1"
+    framer-motion: "npm:10"
     jsdom: "npm:^29.1.1"
     lighthouse: "npm:^8.6.0"
     mkdirp: "npm:^1.0.4"
@@ -6142,7 +6095,7 @@ __metadata:
     react-photo-gallery: "npm:^8.0.0"
     react-syntax-highlighter: "npm:^15.5.0"
     source-map-explorer: "npm:^2.5.3"
-    styled-components: "npm:^5.3.6"
+    styled-components: "npm:6"
     vitest: "npm:^4.1.5"
     webpack: "npm:^5.76.0"
     xml2js: "npm:^0.5.0"
@@ -8928,18 +8881,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"popmotion@npm:11.0.3":
-  version: 11.0.3
-  resolution: "popmotion@npm:11.0.3"
-  dependencies:
-    framesync: "npm:6.0.1"
-    hey-listen: "npm:^1.0.8"
-    style-value-types: "npm:5.0.0"
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/ed196cf034c199a2ab6095f047924b38e24f386c33a182970ad6e1769002b72adff34a72ba7ab2cf34ff5bbfd711ef4caf2e9843ebb7a5c9cafa27c50e525f70
-  languageName: node
-  linkType: hard
-
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -9342,7 +9283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0, react-is@npm:^16.8.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.8.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
@@ -9353,13 +9294,6 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
-  languageName: node
-  linkType: hard
-
-"react-merge-refs@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "react-merge-refs@npm:1.1.0"
-  checksum: 10c0/afb937156d834a058e5021535a63fd8a35984365c38b613478c31186da920b3b469e38b0b161a2075fbf5db7118fb8e96bb8a52a563f271d8f8f166fe8ffe2a4
   languageName: node
   linkType: hard
 
@@ -9484,19 +9418,6 @@ __metadata:
     react: ">=16.6.0"
     react-dom: ">=16.6.0"
   checksum: 10c0/2ba754ba748faefa15f87c96dfa700d5525054a0141de8c75763aae6734af0740e77e11261a1e8f4ffc08fd9ab78510122e05c21c2d79066c38bb6861a886c82
-  languageName: node
-  linkType: hard
-
-"react-use-measure@npm:^2.1.1":
-  version: 2.1.7
-  resolution: "react-use-measure@npm:2.1.7"
-  peerDependencies:
-    react: ">=16.13"
-    react-dom: ">=16.13"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-  checksum: 10c0/ff24130e6f95e853feb6892fb74af08dbc5aae3574b701169e3bc3adb392c3162f51a58ddfe39bb7337db13ae609bbec0bb51a9de8b5fae5420f9d17e1f8b542
   languageName: node
   linkType: hard
 
@@ -10140,13 +10061,6 @@ __metadata:
   dependencies:
     kind-of: "npm:^6.0.2"
   checksum: 10c0/7bab09613a1b9f480c85a9823aebec533015579fa055ba6634aa56ba1f984380670eaf33b8217502931872aa1401c9fcadaa15f9f604d631536df475b05bcf1e
-  languageName: node
-  linkType: hard
-
-"shallowequal@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "shallowequal@npm:1.1.0"
-  checksum: 10c0/b926efb51cd0f47aa9bc061add788a4a650550bbe50647962113a4579b60af2abe7b62f9b02314acc6f97151d4cf87033a2b15fc20852fae306d1a095215396c
   languageName: node
   linkType: hard
 
@@ -10880,35 +10794,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"style-value-types@npm:5.0.0":
-  version: 5.0.0
-  resolution: "style-value-types@npm:5.0.0"
+"styled-components@npm:6":
+  version: 6.4.2
+  resolution: "styled-components@npm:6.4.2"
   dependencies:
-    hey-listen: "npm:^1.0.8"
-    tslib: "npm:^2.1.0"
-  checksum: 10c0/a7b693269d48c0cab73da6c88eade845e71b5f330541a9ccb6a065468739d9bafdeb34f94fb89581931371275846da53e35989218cbc0c2d1a38f127e4d765fd
-  languageName: node
-  linkType: hard
-
-"styled-components@npm:^5.3.6":
-  version: 5.3.11
-  resolution: "styled-components@npm:5.3.11"
-  dependencies:
-    "@babel/helper-module-imports": "npm:^7.0.0"
-    "@babel/traverse": "npm:^7.4.5"
-    "@emotion/is-prop-valid": "npm:^1.1.0"
-    "@emotion/stylis": "npm:^0.8.4"
-    "@emotion/unitless": "npm:^0.7.4"
-    babel-plugin-styled-components: "npm:>= 1.12.0"
-    css-to-react-native: "npm:^3.0.0"
-    hoist-non-react-statics: "npm:^3.0.0"
-    shallowequal: "npm:^1.1.0"
-    supports-color: "npm:^5.5.0"
+    "@emotion/is-prop-valid": "npm:1.4.0"
+    css-to-react-native: "npm:3.2.0"
+    csstype: "npm:3.2.3"
+    stylis: "npm:4.3.6"
   peerDependencies:
+    css-to-react-native: ">= 3.2.0"
     react: ">= 16.8.0"
     react-dom: ">= 16.8.0"
-    react-is: ">= 16.8.0"
-  checksum: 10c0/90b73479770c5d68e22e6366d210119d7203154a3e49dc828f6f6b4c2d5c077f7548210dfddd0af3cb15b0b63fab3eec8dc995c1734e97a313a9b83ba893668e
+    react-native: ">= 0.68.0"
+  peerDependenciesMeta:
+    css-to-react-native:
+      optional: true
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: 10c0/28a021222157ad2cb07b4e4bfb499c27fd85a5d654b97f6faefef79a7b7b10fc3a9db2b3fbc7dc926db64e8e70f86ec2e5188e711b7942585d8c173cb51e6f42
   languageName: node
   linkType: hard
 
@@ -10928,6 +10834,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stylis@npm:4.3.6":
+  version: 4.3.6
+  resolution: "stylis@npm:4.3.6"
+  checksum: 10c0/e736d484983a34f7c65d362c67dc79b7bce388054b261c2b7b23d02eaaf280617033f65d44b1ea341854f4331a5074b885668ac8741f98c13a6cfd6443ae85d0
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -10935,7 +10848,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^5.3.0, supports-color@npm:^5.5.0":
+"supports-color@npm:^5.3.0":
   version: 5.5.0
   resolution: "supports-color@npm:5.5.0"
   dependencies:


### PR DESCRIPTION
## Summary

This pull request updates the v2.5.0b branch with comprehensive test coverage additions, component fixes, and major dependency upgrades.

## Changes

- **Test additions:**
  - Add tests for missing components
  - Fix failing tests for pages component
  - Improve coverage for gallery, carousel, icons, and article components
  
- **Component fixes:**
  - Replace defaultProps with inline default values in Article component
  - Add test for GithubIcon isDark prop
  - Add tests for carousel currentIndex rendering
  - Add tests for gallery sort functionality and edge cases
  
- **Major dependency upgrades:**
  - framer-motion: v10 (breaking changes, uses `mode="wait"` instead of deprecated `exitBeforeEnter`)
  - styled-components: v6 (requires two-dot version in Yarn 4 berry for deterministic builds)
